### PR TITLE
Add Request Trace View and Client Determination Fix

### DIFF
--- a/AuroraTrace/AuroraTrace.xcodeproj/project.pbxproj
+++ b/AuroraTrace/AuroraTrace.xcodeproj/project.pbxproj
@@ -50,7 +50,6 @@
 		9D94C7882C4DDDD500802A5C /* HomeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D94C7872C4DDDD500802A5C /* HomeViewModel.swift */; };
 		9D94C78A2C4DE1D000802A5C /* HomeModule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D94C7892C4DE1D000802A5C /* HomeModule.swift */; };
 		9D94C78D2C4DE40700802A5C /* AuroraTableRowModelTransform.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D94C78C2C4DE40700802A5C /* AuroraTableRowModelTransform.swift */; };
-		9D94C78F2C4EFB7600802A5C /* RequestDetail.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D94C78E2C4EFB7600802A5C /* RequestDetail.swift */; };
 		9D94C7922C4F127F00802A5C /* UAParserSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 9D94C7912C4F127F00802A5C /* UAParserSwift */; };
 /* End PBXBuildFile section */
 
@@ -120,7 +119,6 @@
 		9D94C7872C4DDDD500802A5C /* HomeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewModel.swift; sourceTree = "<group>"; };
 		9D94C7892C4DE1D000802A5C /* HomeModule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeModule.swift; sourceTree = "<group>"; };
 		9D94C78C2C4DE40700802A5C /* AuroraTableRowModelTransform.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuroraTableRowModelTransform.swift; sourceTree = "<group>"; };
-		9D94C78E2C4EFB7600802A5C /* RequestDetail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestDetail.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -264,7 +262,6 @@
 			children = (
 				9D94C7802C4DD98C00802A5C /* TableView */,
 				9D94C73D2C4C376500802A5C /* NativeTextArea.swift */,
-				9D94C78E2C4EFB7600802A5C /* RequestDetail.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -532,7 +529,6 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				9D94C78F2C4EFB7600802A5C /* RequestDetail.swift in Sources */,
 				9D94C73A2C4C310700802A5C /* SocketServerPreeview.swift in Sources */,
 				9D94C78A2C4DE1D000802A5C /* HomeModule.swift in Sources */,
 				9D94C7822C4DDB4A00802A5C /* AuroraTableView.swift in Sources */,

--- a/AuroraTrace/AuroraTrace.xcodeproj/project.pbxproj
+++ b/AuroraTrace/AuroraTrace.xcodeproj/project.pbxproj
@@ -50,6 +50,8 @@
 		9D94C7882C4DDDD500802A5C /* HomeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D94C7872C4DDDD500802A5C /* HomeViewModel.swift */; };
 		9D94C78A2C4DE1D000802A5C /* HomeModule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D94C7892C4DE1D000802A5C /* HomeModule.swift */; };
 		9D94C78D2C4DE40700802A5C /* AuroraTableRowModelTransform.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D94C78C2C4DE40700802A5C /* AuroraTableRowModelTransform.swift */; };
+		9D94C78F2C4EFB7600802A5C /* RequestDetail.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D94C78E2C4EFB7600802A5C /* RequestDetail.swift */; };
+		9D94C7922C4F127F00802A5C /* UAParserSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 9D94C7912C4F127F00802A5C /* UAParserSwift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -118,6 +120,7 @@
 		9D94C7872C4DDDD500802A5C /* HomeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewModel.swift; sourceTree = "<group>"; };
 		9D94C7892C4DE1D000802A5C /* HomeModule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeModule.swift; sourceTree = "<group>"; };
 		9D94C78C2C4DE40700802A5C /* AuroraTableRowModelTransform.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuroraTableRowModelTransform.swift; sourceTree = "<group>"; };
+		9D94C78E2C4EFB7600802A5C /* RequestDetail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestDetail.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -125,6 +128,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9D94C7922C4F127F00802A5C /* UAParserSwift in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -260,6 +264,7 @@
 			children = (
 				9D94C7802C4DD98C00802A5C /* TableView */,
 				9D94C73D2C4C376500802A5C /* NativeTextArea.swift */,
+				9D94C78E2C4EFB7600802A5C /* RequestDetail.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -407,6 +412,9 @@
 			dependencies = (
 			);
 			name = AuroraTrace;
+			packageProductDependencies = (
+				9D94C7912C4F127F00802A5C /* UAParserSwift */,
+			);
 			productName = AuroraTrace;
 			productReference = 9D6E5E6D2C4BEF5300C3B789 /* AuroraTrace.app */;
 			productType = "com.apple.product-type.application";
@@ -479,6 +487,9 @@
 				Base,
 			);
 			mainGroup = 9D6E5E642C4BEF5300C3B789;
+			packageReferences = (
+				9D94C7902C4F127F00802A5C /* XCRemoteSwiftPackageReference "UAParserSwift" */,
+			);
 			productRefGroup = 9D6E5E6E2C4BEF5300C3B789 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -521,6 +532,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9D94C78F2C4EFB7600802A5C /* RequestDetail.swift in Sources */,
 				9D94C73A2C4C310700802A5C /* SocketServerPreeview.swift in Sources */,
 				9D94C78A2C4DE1D000802A5C /* HomeModule.swift in Sources */,
 				9D94C7822C4DDB4A00802A5C /* AuroraTableView.swift in Sources */,
@@ -883,6 +895,25 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		9D94C7902C4F127F00802A5C /* XCRemoteSwiftPackageReference "UAParserSwift" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/malcommac/UAParserSwift.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.2.1;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		9D94C7912C4F127F00802A5C /* UAParserSwift */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 9D94C7902C4F127F00802A5C /* XCRemoteSwiftPackageReference "UAParserSwift" */;
+			productName = UAParserSwift;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 9D6E5E652C4BEF5300C3B789 /* Project object */;
 }

--- a/AuroraTrace/AuroraTrace.xcodeproj/project.pbxproj
+++ b/AuroraTrace/AuroraTrace.xcodeproj/project.pbxproj
@@ -45,6 +45,11 @@
 		9D94C77B2C4D35D400802A5C /* AnyCodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D94C77A2C4D35D400802A5C /* AnyCodable.swift */; };
 		9D94C77D2C4D35F400802A5C /* RequestBody.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D94C77C2C4D35F400802A5C /* RequestBody.swift */; };
 		9D94C77F2C4D362900802A5C /* RequestBodyTransform.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D94C77E2C4D362900802A5C /* RequestBodyTransform.swift */; };
+		9D94C7822C4DDB4A00802A5C /* AuroraTableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D94C7812C4DDB4A00802A5C /* AuroraTableView.swift */; };
+		9D94C7862C4DDDB900802A5C /* HomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D94C7852C4DDDB900802A5C /* HomeView.swift */; };
+		9D94C7882C4DDDD500802A5C /* HomeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D94C7872C4DDDD500802A5C /* HomeViewModel.swift */; };
+		9D94C78A2C4DE1D000802A5C /* HomeModule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D94C7892C4DE1D000802A5C /* HomeModule.swift */; };
+		9D94C78D2C4DE40700802A5C /* AuroraTableRowModelTransform.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D94C78C2C4DE40700802A5C /* AuroraTableRowModelTransform.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -108,6 +113,11 @@
 		9D94C77A2C4D35D400802A5C /* AnyCodable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyCodable.swift; sourceTree = "<group>"; };
 		9D94C77C2C4D35F400802A5C /* RequestBody.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestBody.swift; sourceTree = "<group>"; };
 		9D94C77E2C4D362900802A5C /* RequestBodyTransform.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestBodyTransform.swift; sourceTree = "<group>"; };
+		9D94C7812C4DDB4A00802A5C /* AuroraTableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuroraTableView.swift; sourceTree = "<group>"; };
+		9D94C7852C4DDDB900802A5C /* HomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeView.swift; sourceTree = "<group>"; };
+		9D94C7872C4DDDD500802A5C /* HomeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewModel.swift; sourceTree = "<group>"; };
+		9D94C7892C4DE1D000802A5C /* HomeModule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeModule.swift; sourceTree = "<group>"; };
+		9D94C78C2C4DE40700802A5C /* AuroraTableRowModelTransform.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuroraTableRowModelTransform.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -158,6 +168,7 @@
 		9D6E5E6F2C4BEF5300C3B789 /* AuroraTrace */ = {
 			isa = PBXGroup;
 			children = (
+				9D94C7832C4DDD9B00802A5C /* Features */,
 				9D94C7502C4CA1A700802A5C /* Utils */,
 				9D94C7382C4C30E900802A5C /* UI */,
 				9D94C7372C4C30A600802A5C /* Data */,
@@ -247,6 +258,7 @@
 		9D94C73C2C4C375300802A5C /* Components */ = {
 			isa = PBXGroup;
 			children = (
+				9D94C7802C4DD98C00802A5C /* TableView */,
 				9D94C73D2C4C376500802A5C /* NativeTextArea.swift */,
 			);
 			path = Components;
@@ -342,6 +354,41 @@
 				9D94C77C2C4D35F400802A5C /* RequestBody.swift */,
 			);
 			path = enums;
+			sourceTree = "<group>";
+		};
+		9D94C7802C4DD98C00802A5C /* TableView */ = {
+			isa = PBXGroup;
+			children = (
+				9D94C7812C4DDB4A00802A5C /* AuroraTableView.swift */,
+			);
+			path = TableView;
+			sourceTree = "<group>";
+		};
+		9D94C7832C4DDD9B00802A5C /* Features */ = {
+			isa = PBXGroup;
+			children = (
+				9D94C7842C4DDDA200802A5C /* Home */,
+			);
+			path = Features;
+			sourceTree = "<group>";
+		};
+		9D94C7842C4DDDA200802A5C /* Home */ = {
+			isa = PBXGroup;
+			children = (
+				9D94C78B2C4DE3F100802A5C /* Transform */,
+				9D94C7852C4DDDB900802A5C /* HomeView.swift */,
+				9D94C7872C4DDDD500802A5C /* HomeViewModel.swift */,
+				9D94C7892C4DE1D000802A5C /* HomeModule.swift */,
+			);
+			path = Home;
+			sourceTree = "<group>";
+		};
+		9D94C78B2C4DE3F100802A5C /* Transform */ = {
+			isa = PBXGroup;
+			children = (
+				9D94C78C2C4DE40700802A5C /* AuroraTableRowModelTransform.swift */,
+			);
+			path = Transform;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -475,12 +522,15 @@
 			buildActionMask = 2147483647;
 			files = (
 				9D94C73A2C4C310700802A5C /* SocketServerPreeview.swift in Sources */,
+				9D94C78A2C4DE1D000802A5C /* HomeModule.swift in Sources */,
+				9D94C7822C4DDB4A00802A5C /* AuroraTableView.swift in Sources */,
 				9D94C7712C4CB56B00802A5C /* SocketMessageTypeTransform.swift in Sources */,
 				9D94C7652C4CB03F00802A5C /* MessageProcessingUseCase.swift in Sources */,
 				9D94C77D2C4D35F400802A5C /* RequestBody.swift in Sources */,
 				9D94C7342C4C27F100802A5C /* ServerSocket.swift in Sources */,
 				9D94C7572C4CA24000802A5C /* HttpRequestTransform.swift in Sources */,
 				9D94C7432C4C99CA00802A5C /* AppView.swift in Sources */,
+				9D94C7862C4DDDB900802A5C /* HomeView.swift in Sources */,
 				9D94C7482C4C9A6400802A5C /* RequestService.swift in Sources */,
 				9D94C7792C4D35B400802A5C /* RequestBodyDto.swift in Sources */,
 				9D94C7682C4CB3B100802A5C /* DynamicSerialize.swift in Sources */,
@@ -491,11 +541,13 @@
 				9D94C7612C4CAEE300802A5C /* SocketRepositoryDelegate.swift in Sources */,
 				9D94C7462C4C9A0B00802A5C /* AppService.swift in Sources */,
 				9D94C74C2C4C9AE600802A5C /* HttpRequest.swift in Sources */,
+				9D94C7882C4DDDD500802A5C /* HomeViewModel.swift in Sources */,
 				9D94C76D2C4CB4F200802A5C /* SSLState.swift in Sources */,
 				9D94C7632C4CAEFC00802A5C /* SocketRepository.swift in Sources */,
 				9D94C7522C4CA1BE00802A5C /* Operators.swift in Sources */,
 				9D6E5E752C4BEF5300C3B789 /* Item.swift in Sources */,
 				9D6E5E712C4BEF5300C3B789 /* AuroraTraceApp.swift in Sources */,
+				9D94C78D2C4DE40700802A5C /* AuroraTableRowModelTransform.swift in Sources */,
 				9D94C73E2C4C376500802A5C /* NativeTextArea.swift in Sources */,
 				9D94C7542C4CA21200802A5C /* Transformable.swift in Sources */,
 				9D94C76F2C4CB52300802A5C /* SocketMessageType.swift in Sources */,

--- a/AuroraTrace/AuroraTrace/AuroraTraceApp.swift
+++ b/AuroraTrace/AuroraTrace/AuroraTraceApp.swift
@@ -13,7 +13,7 @@ import UniformTypeIdentifiers
 struct AuroraTraceApp: App {
     var body: some Scene {
         Window("AuroraTrace", id: "Home") {
-            SocketServerPreeview()
+            AnyView(HomeModule.build())
         }
     }
 }

--- a/AuroraTrace/AuroraTrace/Data/Models/Dto/RequestBodyDto.swift
+++ b/AuroraTrace/AuroraTrace/Data/Models/Dto/RequestBodyDto.swift
@@ -6,34 +6,42 @@
 //
 
 import Foundation
+
 enum RequestBodyDto: Codable {
     case dictionary([String: AnyCodable])
+    case array([String])
     case string(String)
     case data(Data)
     case empty
-
+    
     init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
-        if let dict = try? container.decode([String: AnyCodable].self) {
-            self = .dictionary(dict)
-        } else if let str = try? container.decode(String.self) {
-            self = .string(str)
+        
+        if container.decodeNil() {
+            self = .empty
+        } else if let dictionary = try? container.decode([String: AnyCodable].self) {
+            self = .dictionary(dictionary)
+        } else if let array = try? container.decode([String].self) {
+            self = .array(array)
+        } else if let string = try? container.decode(String.self) {
+            self = .string(string)
         } else if let data = try? container.decode(Data.self) {
             self = .data(data)
-        } else if container.decodeNil() {
-            self = .empty
         } else {
-            throw DecodingError.dataCorruptedError(in: container, debugDescription: "Cannot decode request body")
+            self = .empty
         }
     }
-
+    
     func encode(to encoder: Encoder) throws {
         var container = encoder.singleValueContainer()
+        
         switch self {
-        case .dictionary(let dict):
-            try container.encode(dict)
-        case .string(let str):
-            try container.encode(str)
+        case .dictionary(let dictionary):
+            try container.encode(dictionary)
+        case .array(let array):
+            try container.encode(array)
+        case .string(let string):
+            try container.encode(string)
         case .data(let data):
             try container.encode(data)
         case .empty:
@@ -41,3 +49,4 @@ enum RequestBodyDto: Codable {
         }
     }
 }
+

--- a/AuroraTrace/AuroraTrace/Data/Models/Dto/RequestDto.swift
+++ b/AuroraTrace/AuroraTrace/Data/Models/Dto/RequestDto.swift
@@ -8,6 +8,7 @@
 import Foundation
                 
 struct HttpRequestDto: Codable {
+    let id: String
     let method: String
     let url: String
     let path: String
@@ -25,6 +26,7 @@ struct HttpRequestDto: Codable {
     let sslState: String
 
     enum CodingKeys: String, CodingKey {
+        case id
         case method
         case url
         case path
@@ -44,6 +46,7 @@ struct HttpRequestDto: Codable {
     
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.id = try container.decode(String.self, forKey: .id)
         self.method = try container.decode(String.self, forKey: .method)
         self.url = try container.decode(String.self, forKey: .url)
         self.path = try container.decode(String.self, forKey: .path)

--- a/AuroraTrace/AuroraTrace/Data/Models/Entity/HttpRequest.swift
+++ b/AuroraTrace/AuroraTrace/Data/Models/Entity/HttpRequest.swift
@@ -7,19 +7,20 @@
 
 import Foundation
 struct HttpRequest {
-    let method: String
-    let url: String
-    let path: String
-    let headers: [String: String]
-    let query: [String: String]
-    let host: String
-    let port: Int
-    let scheme: String
-    let body: RequestBody?
-    let content: Data?
-    let fullURL: String
-    let timestampStart: TimeInterval
-    let timestampEnd: TimeInterval
-    let cookies: [String: String]
-    let sslState: SSLState
+    var id: String
+    var method: String
+    var url: String
+    var path: String
+    var headers: [String: String]
+    var query: [String: String]
+    var host: String
+    var port: Int
+    var scheme: String
+    var body: RequestBody?
+    var content: Data?
+    var fullURL: String
+    var timestampStart: TimeInterval
+    var timestampEnd: TimeInterval
+    var cookies: [String: String]
+    var sslState: SSLState
 }

--- a/AuroraTrace/AuroraTrace/Data/Models/Entity/SocketMessage.swift
+++ b/AuroraTrace/AuroraTrace/Data/Models/Entity/SocketMessage.swift
@@ -7,6 +7,5 @@
 
 import Foundation
 struct SocketMessage {
-    var messageType: SocketMessageType
     var content: DynamicDecodable
 }

--- a/AuroraTrace/AuroraTrace/Data/Models/Entity/enums/RequestBody.swift
+++ b/AuroraTrace/AuroraTrace/Data/Models/Entity/enums/RequestBody.swift
@@ -8,6 +8,7 @@
 import Foundation
 enum RequestBody: Codable {
     case dictionary([String: AnyCodable])
+    case array([String])
     case string(String)
     case data(Data)
     case empty

--- a/AuroraTrace/AuroraTrace/Data/Models/Entity/enums/SSLState.swift
+++ b/AuroraTrace/AuroraTrace/Data/Models/Entity/enums/SSLState.swift
@@ -7,7 +7,8 @@
 
 import Foundation
 enum SSLState: String {
-    case open
-    case closed
-    case uknow
+    case open = "Open"
+    case closed = "Closed"
+    case pending = "Pendig"
+    case uknow = ""
 }

--- a/AuroraTrace/AuroraTrace/Data/Models/Transformables/HttpRequestTransform.swift
+++ b/AuroraTrace/AuroraTrace/Data/Models/Transformables/HttpRequestTransform.swift
@@ -12,8 +12,9 @@ struct HttpRequestTransform: Transformable {
     typealias OutputType = HttpRequest
     
     static func transform(_ input: HttpRequestDto) -> HttpRequest {
-        .init(method: input.method,
-              url: input.url,
+        .init(id: input.id,
+              method: input.method,
+              url: input.host,
               path: input.path,
               headers: input.headers,
               query: input.query,

--- a/AuroraTrace/AuroraTrace/Data/Models/Transformables/HttpRequestTransform.swift
+++ b/AuroraTrace/AuroraTrace/Data/Models/Transformables/HttpRequestTransform.swift
@@ -29,6 +29,7 @@ struct HttpRequestTransform: Transformable {
               cookies: input.cookies,
               sslState: input.sslState.transform())
     }
+    
 }
 
 extension HttpRequestDto {

--- a/AuroraTrace/AuroraTrace/Data/Models/Transformables/RequestBodyTransform.swift
+++ b/AuroraTrace/AuroraTrace/Data/Models/Transformables/RequestBodyTransform.swift
@@ -21,6 +21,8 @@ struct RequestBodyTransform: Transformable {
             return .data(data)
         case .empty:
             return .empty
+        case .array(let array):
+            return .array(array)
         }
     }
 }

--- a/AuroraTrace/AuroraTrace/Data/Models/Transformables/SocketMessageTranform.swift
+++ b/AuroraTrace/AuroraTrace/Data/Models/Transformables/SocketMessageTranform.swift
@@ -12,8 +12,6 @@ struct SocketMessageTranform: Transformable {
     typealias OutputType = SocketMessage
     
     static func transform(_ input: SocketMessageDto) -> SocketMessage {
-        fatalError("Disabled")
-//        SocketMessage(messageType: input.messageType.transform(),
-//                      content: input.content)
+        SocketMessage(content: input.content)
     }
 }

--- a/AuroraTrace/AuroraTrace/Data/Repository/AuroraBridgeSocketRepository.swift
+++ b/AuroraTrace/AuroraTrace/Data/Repository/AuroraBridgeSocketRepository.swift
@@ -13,10 +13,10 @@ class AuroraBridgeSocketRepository: SocketRepository {
     weak var delegate: SocketRepositoryDelegate?
     private let server: AuroraBridgeSocket
     
-     init() throws {
+    init() throws {
         try self.server = .init()
     }
-
+    
     func connect() {
         do {
             try server.start()
@@ -26,26 +26,21 @@ class AuroraBridgeSocketRepository: SocketRepository {
                 guard let self = self else {
                     return
                 }
-                do {
-                    switch response {
-                    case .success(let success):
-                        
-                        delegate?.didReceiveMessage(success)
-                    case .failure(let failure):
-                        print(failure)
-                    }
+                switch response {
+                case .success(let success):
                     
-                } catch {
-                    print(error)
+                    await delegate?.didReceiveMessage(success)
+                case .failure(let failure):
+                    print(failure)
                 }
             }
         } catch {
-            
+            print("Error")
         }
     }
-
+    
     func disconnect() {
         server.stop()
     }
-
+    
 }

--- a/AuroraTrace/AuroraTrace/Data/Repository/SocketRepositoryDelegate.swift
+++ b/AuroraTrace/AuroraTrace/Data/Repository/SocketRepositoryDelegate.swift
@@ -7,5 +7,7 @@
 
 import Foundation
 protocol SocketRepositoryDelegate: AnyObject {
-    func didReceiveMessage(_ message: Data)
+    
+    @MainActor
+    func didReceiveMessage(_ message: Data) async
 }

--- a/AuroraTrace/AuroraTrace/Data/Socket/AuroraBridgeSocket.swift
+++ b/AuroraTrace/AuroraTrace/Data/Socket/AuroraBridgeSocket.swift
@@ -87,7 +87,7 @@ final class AuroraBridgeSocket: ServerSocket {
                 guard let self = self else { return }
                 if let data = data, !data.isEmpty {
                     await self.onReceiveMessage?(.success(data))
-                    try? await Task.sleep(nanoseconds: 2_000_000_000)
+                    
                     self.sendResponse(to: connection, message: data)
                 } else {
                     if let error = error {

--- a/AuroraTrace/AuroraTrace/Data/Socket/ServerSocket.swift
+++ b/AuroraTrace/AuroraTrace/Data/Socket/ServerSocket.swift
@@ -12,7 +12,7 @@ protocol ServerSocket: AnyObject {
     var isRunning: Bool { get }
     func start() throws
     func stop()
-    func receive(message completion: @escaping (Result<Data, any Error>) -> Void) -> Self
+    func receive(message completion: @MainActor @escaping (Result<Data, any Error>) async -> Void) -> Self
     func send(message data: @escaping () -> Data)
     func receive(status completion: ((ConnectionStatus) -> Void)?) -> Self
 }

--- a/AuroraTrace/AuroraTrace/Domain/MessageProcessingUseCase.swift
+++ b/AuroraTrace/AuroraTrace/Domain/MessageProcessingUseCase.swift
@@ -8,28 +8,48 @@
 import Foundation
 final class MessageProcessingUseCase {
     private var socketRepository: SocketRepository
+    private var httpRequestCallBacks: [@MainActor (HttpRequest) async -> Void] = []
     
     init(socketRepository: SocketRepository) {
         self.socketRepository = socketRepository
         self.socketRepository.delegate = self
     }
     
-    func execute() {
+    @discardableResult
+    func execute() -> Self {
         socketRepository.connect()
+        return self
     }
-
+    
+    @discardableResult
+    func suscribe(on complete: @escaping (HttpRequest) -> Void) -> Self {
+        httpRequestCallBacks.append(complete)
+        return self
+    }
+    
     func stop() {
         socketRepository.disconnect()
     }
 }
 
 extension MessageProcessingUseCase: SocketRepositoryDelegate {
-    func didReceiveMessage(_ message: Data) {
+    
+    @MainActor
+    func didReceiveMessage(_ message: Data) async {
         print("Received update: \(message)")
         
         do {
-            let messageResponse: SocketMessageDto = try .from(data: message)
-            print("Message result \(dump(messageResponse))")
+            let socketMessage: SocketMessageDto = try .from(data: message)
+            switch socketMessage.content.value {
+            case let request as HttpRequestDto:
+                for item in httpRequestCallBacks {
+                    await item(request.transform())
+                }
+                break
+            default:
+                break
+            }
+            
         } catch {
             print("Error Message Invalid: \(message)")
         }

--- a/AuroraTrace/AuroraTrace/Features/Home/HomeModule.swift
+++ b/AuroraTrace/AuroraTrace/Features/Home/HomeModule.swift
@@ -1,0 +1,23 @@
+//
+//  HomeModule.swift
+//  AuroraTrace
+//
+//  Created by Saldivar on 21/07/24.
+//
+
+import SwiftUI
+
+struct HomeModule {
+    
+    static func build() -> any View {
+        do {
+            let auroraBridgeSocketRepository = try AuroraBridgeSocketRepository()
+            let messageProcesssingCase = MessageProcessingUseCase(socketRepository: auroraBridgeSocketRepository)
+            let homeViewModel = HomeViewModel(tableView: .init(), messageProcesssingCase: messageProcesssingCase)
+            return HomeView(model: homeViewModel)
+        } catch {
+            print(error.localizedDescription)
+        }
+        return EmptyView()
+    }
+}

--- a/AuroraTrace/AuroraTrace/Features/Home/HomeView.swift
+++ b/AuroraTrace/AuroraTrace/Features/Home/HomeView.swift
@@ -17,18 +17,15 @@ struct HomeView: View {
     }
     
     var body: some View {
-        AuroraTableView(model: $viewModel.tableView)
-            .onChange(of: model.tableView, perform: { newValue in
-                if newValue.items.count > 0 {
-                    viewModel.addItem(newValue.items.last!)
-                }
-            })
-            .onAppear(perform: {
-                if !isLoading {
-                    isLoading.toggle()
-                    model.initialize()
-                }
-            })
+        HSplitView(content: {      
+            AuroraTableViewV2(viewModel: $model.tableView)
+        }).onAppear(perform: {
+            if !isLoading {
+                isLoading.toggle()
+                model.initialize()
+            }
+        })
+        
     }
     
 }

--- a/AuroraTrace/AuroraTrace/Features/Home/HomeView.swift
+++ b/AuroraTrace/AuroraTrace/Features/Home/HomeView.swift
@@ -9,7 +9,6 @@ import SwiftUI
 
 struct HomeView: View {
     @StateObject var model: HomeViewModel
-    @StateObject var viewModel = AuroraTableViewModel()
     @State var isLoading: Bool = false
     
     init(model: HomeViewModel) {
@@ -18,7 +17,7 @@ struct HomeView: View {
     
     var body: some View {
         HSplitView(content: {      
-            AuroraTableViewV2(viewModel: $model.tableView)
+            AuroraTableView(viewModel: $model.tableView)
         }).onAppear(perform: {
             if !isLoading {
                 isLoading.toggle()

--- a/AuroraTrace/AuroraTrace/Features/Home/HomeView.swift
+++ b/AuroraTrace/AuroraTrace/Features/Home/HomeView.swift
@@ -1,0 +1,39 @@
+//
+//  HomeView.swift
+//  AuroraTrace
+//
+//  Created by Saldivar on 21/07/24.
+//
+
+import SwiftUI
+
+struct HomeView: View {
+    @StateObject var model: HomeViewModel
+    @StateObject var viewModel = AuroraTableViewModel()
+    @State var isLoading: Bool = false
+    
+    init(model: HomeViewModel) {
+        self._model = StateObject.init(wrappedValue: model)
+    }
+    
+    var body: some View {
+        AuroraTableView(model: $viewModel.tableView)
+            .onChange(of: model.tableView, perform: { newValue in
+                if newValue.items.count > 0 {
+                    viewModel.addItem(newValue.items.last!)
+                }
+            })
+            .onAppear(perform: {
+                if !isLoading {
+                    isLoading.toggle()
+                    model.initialize()
+                }
+            })
+    }
+    
+}
+
+#Preview {
+    HomeView(model: .init(tableView: .init(),
+                          messageProcesssingCase: .init(socketRepository: try! AuroraBridgeSocketRepository())))
+}

--- a/AuroraTrace/AuroraTrace/Features/Home/HomeViewModel.swift
+++ b/AuroraTrace/AuroraTrace/Features/Home/HomeViewModel.swift
@@ -1,0 +1,33 @@
+//
+//  HomeViewModel.swift
+//  AuroraTrace
+//
+//  Created by Saldivar on 21/07/24.
+//
+
+import SwiftUI
+
+final class HomeViewModel: ObservableObject {
+    @Published var tableView: AuroraTableView.AuroraTableViewModel
+    private var messageProcesssingCase: MessageProcessingUseCase
+    
+    init(tableView: AuroraTableView.AuroraTableViewModel,
+         messageProcesssingCase: MessageProcessingUseCase) {
+        self.tableView = tableView
+        self.messageProcesssingCase = messageProcesssingCase
+    }
+    
+    func initialize() {
+        
+        messageProcesssingCase
+            .suscribe { [weak self] request in
+                guard let self = self else { return}
+                self.tableView.items.append(request.transform())
+                
+            }.execute()
+    }
+    
+    deinit {
+        messageProcesssingCase.stop()
+    }
+}

--- a/AuroraTrace/AuroraTrace/Features/Home/Transform/AuroraTableRowModelTransform.swift
+++ b/AuroraTrace/AuroraTrace/Features/Home/Transform/AuroraTableRowModelTransform.swift
@@ -1,0 +1,36 @@
+//
+//  AuroraTableRowModelTransform.swift
+//  AuroraTrace
+//
+//  Created by Saldivar on 21/07/24.
+//
+
+import Foundation
+
+struct AuroraTableRowModelTransform: Transformable {
+    typealias InputType = HttpRequest
+    
+    typealias OutputType = AuroraTableView.AuroraTableRowModel
+    
+    static func transform(_ input: HttpRequest) -> AuroraTableView.AuroraTableRowModel {
+        .init(id: input.id,
+              url: input.url,
+              client: getClient(input.headers),
+              method: input.method,
+              status: "",
+              code: "",
+              time: "..",
+              duration: "..",
+              ssl: input.sslState.rawValue)
+    }
+    
+    private static func getClient(_ headers: [String: String]) -> String {
+        return headers["User-Agent"] ?? "uknow"
+    }
+}
+
+extension HttpRequest {
+    func transform() -> AuroraTableView.AuroraTableRowModel {
+        AuroraTableRowModelTransform.transform(self)
+    }
+}

--- a/AuroraTrace/AuroraTrace/UI/Components/TableView/AuroraTableView.swift
+++ b/AuroraTrace/AuroraTrace/UI/Components/TableView/AuroraTableView.swift
@@ -8,9 +8,6 @@
 import AppKit
 import SwiftUI
 
-import SwiftUI
-import AppKit
-
 // MARK: - Model Definitions
 extension AuroraTableView {
     struct AuroraTableViewModel: Equatable {
@@ -30,149 +27,61 @@ extension AuroraTableView {
     }
 }
 
-// MARK: - AuroraTableView
-struct AuroraTableView: NSViewRepresentable {
-    @Binding var model: AuroraTableViewModel
+extension String {
+    func contains(of str: String) -> Bool {
+        self.lowercased().contains(str.lowercased())
+    }
+}
 
-    func makeCoordinator() -> Coordinator {
-        Coordinator(self)
+struct AuroraTableView: View {
+    @Binding var viewModel: AuroraTableView.AuroraTableViewModel
+    @State private var scrollTarget: String?
+    @State private var selection: String? = nil
+    @State private var filterText: String = ""
+
+    var filteredItems: [AuroraTableView.AuroraTableRowModel] {
+        if filterText.isEmpty {
+            return viewModel.items
+        } else {
+            return viewModel.items.filter { $0.url.contains(of: filterText) || $0.client.contains(of: filterText) || $0.method.contains(of: filterText) || $0.status.contains(of: filterText) || $0.code.contains(of: filterText) || $0.time.contains(of: filterText) || $0.duration.contains(of: filterText) || $0.ssl.contains(of: filterText) }
+        }
     }
 
-    func makeNSView(context: Context) -> NSScrollView {
-            let scrollView = NSScrollView()
-            let tableView = NSTableView()
-
-            let columns: [(String, String, CGFloat)] = [
-                ("ID", "id", 100),
-                ("URL", "url", 300),
-                ("Client", "client", 100),
-                ("Method", "method", 80),
-                ("Status", "status", 80),
-                ("Code", "code", 80),
-                ("Time", "time", 120),
-                ("Duration", "duration", 100),
-                ("SSL", "ssl", 60)
-            ]
-
-            for (title, identifier, width) in columns {
-                let column = NSTableColumn(identifier: NSUserInterfaceItemIdentifier(identifier))
-                column.title = title
-                column.width = width
-                column.minWidth = 50
-                column.maxWidth = 1000
-                column.isEditable = false
-                tableView.addTableColumn(column)
-            }
-
-            tableView.columnAutoresizingStyle = .sequentialColumnAutoresizingStyle
-            tableView.usesAutomaticRowHeights = true
-            tableView.style = .fullWidth
-
-            tableView.dataSource = context.coordinator
-            tableView.delegate = context.coordinator
-
-            scrollView.documentView = tableView
-            scrollView.hasVerticalScroller = true
-            
-            tableView.wantsLayer = true
-            tableView.layer?.isOpaque = true
-
-            context.coordinator.tableView = tableView
-            return scrollView
-        }
-
-    
-    func updateNSView(_ nsView: NSScrollView, context: Context) {
-        guard let tableView = nsView.documentView as? NSTableView else { return }
-        
-        if context.coordinator.model != model {
-            context.coordinator.model = model
-            tableView.reloadData()
-            
-            if context.coordinator.shouldScrollToBottom {
-                scrollToBottom(scrollView: nsView)
-                context.coordinator.shouldScrollToBottom = false
-            }
-        }
-    }
-    
-    private func scrollToBottom(scrollView: NSScrollView) {
-        guard let documentView = scrollView.documentView else { return }
-        let newOrigin = NSPoint(x: 0, y: max(0, documentView.frame.height - scrollView.contentSize.height))
-        documentView.scroll(newOrigin)
-    }
-
-    // MARK: - Coordinator
-    class Coordinator: NSObject, NSTableViewDataSource, NSTableViewDelegate {
-        var parent: AuroraTableView
-        var tableView: NSTableView!
-        var model: AuroraTableViewModel
-        var shouldScrollToBottom = false
-
-        init(_ parent: AuroraTableView) {
-            self.parent = parent
-            self.model = parent.model
-        }
-
-        func numberOfRows(in tableView: NSTableView) -> Int {
-            return model.items.count
-        }
-
-        func tableView(_ tableView: NSTableView, viewFor tableColumn: NSTableColumn?, row: Int) -> NSView? {
-                    guard let tableColumn = tableColumn else { return nil }
-                    let item = model.items[row]
-                    
-                    let text: String = {
-                        switch tableColumn.identifier.rawValue {
-                        case "id": return String(row)
-                        case "url": return item.url
-                        case "client": return item.client.isEmpty ? "Unknown" : item.client
-                        case "method": return item.method
-                        case "status": return item.status
-                        case "code": return item.code
-                        case "time": return item.time
-                        case "duration": return item.duration
-                        case "ssl": return item.ssl
-                        default: return ""
+    var body: some View {
+        VStack {
+            TextField("Filter", text: $filterText)
+                .padding()
+                .textFieldStyle(RoundedBorderTextFieldStyle())
+            GeometryReader { contentProxy in
+                ScrollViewReader { proxy in
+                    ScrollView {
+                        Table(filteredItems, selection: $selection) {
+                            TableColumn("URL", value: \.url)
+                            TableColumn("Client", value: \.client)
+                            TableColumn("Method", value: \.method)
+                            TableColumn("Status", value: \.status)
+                            TableColumn("Code", value: \.code)
+                            TableColumn("Time", value: \.time)
+                            TableColumn("Duration", value: \.duration)
+                            TableColumn("SSL", value: \.ssl)
                         }
-                    }()
-
-                    let cellIdentifier = NSUserInterfaceItemIdentifier(rawValue: "Cell")
-                    let cell: NSTextField
-                    if let existingCell = tableView.makeView(withIdentifier: cellIdentifier, owner: nil) as? NSTextField {
-                        cell = existingCell
-                    } else {
-                        cell = NSTextField(wrappingLabelWithString: "")
-                        cell.identifier = cellIdentifier
-                        cell.isEditable = false
-                        cell.drawsBackground = false
-                        cell.isBordered = false
-                        cell.maximumNumberOfLines = 2
-                        cell.lineBreakMode = .byTruncatingTail
-                        cell.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+                        .frame(height: contentProxy.size.height)
+                        .onChange(of: viewModel.items) { old, newItems in
+                            if let lastId = newItems.last?.id, selection == nil {
+                                scrollTarget = lastId
+                            }
+                        }
                     }
-                    cell.stringValue = text
-                    return cell
+                    .onChange(of: scrollTarget) { old, target in
+                        if let target = target {
+                            withAnimation {
+                                proxy.scrollTo(target, anchor: .bottomLeading)
+                            }
+                        }
+                    }
                 }
-
-        func tableView(_ tableView: NSTableView, heightOfRow row: Int) -> CGFloat {
-            return 40 // Adjust this value as needed
+            }
         }
     }
 }
 
-// MARK: - ViewModel
-class AuroraTableViewModel: ObservableObject {
-    @Published var tableView = AuroraTableView.AuroraTableViewModel()
-    
-    func addItem(_ item: AuroraTableView.AuroraTableRowModel) {
-        DispatchQueue.main.async {
-            self.tableView.items.append(item)
-            NotificationCenter.default.post(name: .scrollToBottom, object: nil)
-        }
-    }
-}
-
-extension Notification.Name {
-    static let scrollToBottom = Notification.Name("scrollToBottom")
-}

--- a/AuroraTrace/AuroraTrace/UI/Components/TableView/AuroraTableView.swift
+++ b/AuroraTrace/AuroraTrace/UI/Components/TableView/AuroraTableView.swift
@@ -1,0 +1,178 @@
+//
+//  AuroraTableView.swift
+//  AuroraTrace
+//
+//  Created by Saldivar on 21/07/24.
+//
+
+import AppKit
+import SwiftUI
+
+import SwiftUI
+import AppKit
+
+// MARK: - Model Definitions
+extension AuroraTableView {
+    struct AuroraTableViewModel: Equatable {
+        var items: [AuroraTableRowModel] = []
+    }
+    
+    struct AuroraTableRowModel: Identifiable, Equatable {
+        let id: String
+        let url: String
+        let client: String
+        let method: String
+        let status: String
+        let code: String
+        let time: String
+        let duration: String
+        let ssl: String
+    }
+}
+
+// MARK: - AuroraTableView
+struct AuroraTableView: NSViewRepresentable {
+    @Binding var model: AuroraTableViewModel
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(self)
+    }
+
+    func makeNSView(context: Context) -> NSScrollView {
+            let scrollView = NSScrollView()
+            let tableView = NSTableView()
+
+            let columns: [(String, String, CGFloat)] = [
+                ("ID", "id", 100),
+                ("URL", "url", 300),
+                ("Client", "client", 100),
+                ("Method", "method", 80),
+                ("Status", "status", 80),
+                ("Code", "code", 80),
+                ("Time", "time", 120),
+                ("Duration", "duration", 100),
+                ("SSL", "ssl", 60)
+            ]
+
+            for (title, identifier, width) in columns {
+                let column = NSTableColumn(identifier: NSUserInterfaceItemIdentifier(identifier))
+                column.title = title
+                column.width = width
+                column.minWidth = 50
+                column.maxWidth = 1000
+                column.isEditable = false
+                tableView.addTableColumn(column)
+            }
+
+            tableView.columnAutoresizingStyle = .sequentialColumnAutoresizingStyle
+            tableView.usesAutomaticRowHeights = true
+            tableView.style = .fullWidth
+
+            tableView.dataSource = context.coordinator
+            tableView.delegate = context.coordinator
+
+            scrollView.documentView = tableView
+            scrollView.hasVerticalScroller = true
+            
+            tableView.wantsLayer = true
+            tableView.layer?.isOpaque = true
+
+            context.coordinator.tableView = tableView
+            return scrollView
+        }
+
+    
+    func updateNSView(_ nsView: NSScrollView, context: Context) {
+        guard let tableView = nsView.documentView as? NSTableView else { return }
+        
+        if context.coordinator.model != model {
+            context.coordinator.model = model
+            tableView.reloadData()
+            
+            if context.coordinator.shouldScrollToBottom {
+                scrollToBottom(scrollView: nsView)
+                context.coordinator.shouldScrollToBottom = false
+            }
+        }
+    }
+    
+    private func scrollToBottom(scrollView: NSScrollView) {
+        guard let documentView = scrollView.documentView else { return }
+        let newOrigin = NSPoint(x: 0, y: max(0, documentView.frame.height - scrollView.contentSize.height))
+        documentView.scroll(newOrigin)
+    }
+
+    // MARK: - Coordinator
+    class Coordinator: NSObject, NSTableViewDataSource, NSTableViewDelegate {
+        var parent: AuroraTableView
+        var tableView: NSTableView!
+        var model: AuroraTableViewModel
+        var shouldScrollToBottom = false
+
+        init(_ parent: AuroraTableView) {
+            self.parent = parent
+            self.model = parent.model
+        }
+
+        func numberOfRows(in tableView: NSTableView) -> Int {
+            return model.items.count
+        }
+
+        func tableView(_ tableView: NSTableView, viewFor tableColumn: NSTableColumn?, row: Int) -> NSView? {
+                    guard let tableColumn = tableColumn else { return nil }
+                    let item = model.items[row]
+                    
+                    let text: String = {
+                        switch tableColumn.identifier.rawValue {
+                        case "id": return String(row)
+                        case "url": return item.url
+                        case "client": return item.client.isEmpty ? "Unknown" : item.client
+                        case "method": return item.method
+                        case "status": return item.status
+                        case "code": return item.code
+                        case "time": return item.time
+                        case "duration": return item.duration
+                        case "ssl": return item.ssl
+                        default: return ""
+                        }
+                    }()
+
+                    let cellIdentifier = NSUserInterfaceItemIdentifier(rawValue: "Cell")
+                    let cell: NSTextField
+                    if let existingCell = tableView.makeView(withIdentifier: cellIdentifier, owner: nil) as? NSTextField {
+                        cell = existingCell
+                    } else {
+                        cell = NSTextField(wrappingLabelWithString: "")
+                        cell.identifier = cellIdentifier
+                        cell.isEditable = false
+                        cell.drawsBackground = false
+                        cell.isBordered = false
+                        cell.maximumNumberOfLines = 2
+                        cell.lineBreakMode = .byTruncatingTail
+                        cell.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+                    }
+                    cell.stringValue = text
+                    return cell
+                }
+
+        func tableView(_ tableView: NSTableView, heightOfRow row: Int) -> CGFloat {
+            return 40 // Adjust this value as needed
+        }
+    }
+}
+
+// MARK: - ViewModel
+class AuroraTableViewModel: ObservableObject {
+    @Published var tableView = AuroraTableView.AuroraTableViewModel()
+    
+    func addItem(_ item: AuroraTableView.AuroraTableRowModel) {
+        DispatchQueue.main.async {
+            self.tableView.items.append(item)
+            NotificationCenter.default.post(name: .scrollToBottom, object: nil)
+        }
+    }
+}
+
+extension Notification.Name {
+    static let scrollToBottom = Notification.Name("scrollToBottom")
+}

--- a/AuroraTrace/AuroraTrace/Utils/Serializer/Decodable+deserialización.swift
+++ b/AuroraTrace/AuroraTrace/Utils/Serializer/Decodable+deserialización.swift
@@ -30,6 +30,7 @@ extension Decodable {
         } catch let DecodingError.dataCorrupted(context) {
             print("Data corrupted: \(context.debugDescription)")
             print("CodingPath: \(context.codingPath)")
+            print("Json: \(jsonString)")
             throw DecodingError.dataCorrupted(context)
         } catch let DecodingError.keyNotFound(key, context) {
             print("Key '\(key)' not found: \(context.debugDescription)")
@@ -58,6 +59,7 @@ extension Decodable {
         } catch let DecodingError.dataCorrupted(context) {
             print("Data corrupted: \(context.debugDescription)")
             print("CodingPath: \(context.codingPath)")
+            print("Json: \(String(data: data, encoding: .utf8))")
             throw DecodingError.dataCorrupted(context)
         } catch let DecodingError.keyNotFound(key, context) {
             print("Key '\(key)' not found: \(context.debugDescription)")

--- a/AuroraTracePy/Redame.md
+++ b/AuroraTracePy/Redame.md
@@ -46,3 +46,8 @@ python3 main.py setup_proxy
 ``` sh
 deactivate
 ```
+
+8.- **Runn**:
+``` sh
+python3 main.py setup_proxy
+```

--- a/AuroraTracePy/models/Models.py
+++ b/AuroraTracePy/models/Models.py
@@ -5,3 +5,4 @@ from enum import Enum
 class SSLState(Enum):
     OPEN = "Open"
     CLOSED = "Closed"
+    PENDING = "Pendig"

--- a/AuroraTracePy/server/ProxyServer/RequestInterceptor.py
+++ b/AuroraTracePy/server/ProxyServer/RequestInterceptor.py
@@ -21,11 +21,10 @@ class RequestInterceptor:
     def request(self, flow: http.HTTPFlow) -> None:
         # Mapear los datos de la solicitud
         # Determinar el estado de SSL/TLS basado en el esquema
-        ssl_state = SSLState.OPEN.value if flow.request.scheme == "https" else SSLState.CLOSED.value
-
-        
+        ssl_state = SSLState.PENDING.value
         request_data = {
             "content": {
+                "id": flow.id,
                 "type": "HttpRequestDto",
                 "method": flow.request.method,
                 "url": flow.request.url,

--- a/AuroraTracePy/server/SocketServer.py
+++ b/AuroraTracePy/server/SocketServer.py
@@ -1,23 +1,40 @@
 import socket
 import json
+import logging
+
+# Configuración del logger
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
 
 def send_request_to_swift(request_data):
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-        s.connect(('127.0.0.1', 65432))
-        message = json.dumps(request_data)
-        s.sendall(message.encode('utf-8'))
+    host = '127.0.0.1'
+    port = 65432
+    
+    try:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            s.connect((host, port))
+            message = json.dumps(request_data)
+            s.sendall(message.encode('utf-8'))
 
-        # Recibe la respuesta del servidor
-        response = s.recv(65536)
-        
-        # Decodifica la respuesta
-        decoded_response = response.decode('utf-8')
-        
-        # Maneja la respuesta vacía
-        if not decoded_response:
-            # Si la respuesta está vacía, puedes simplemente retornar un valor por defecto o continuar
-            return {}  # Puedes cambiar esto a lo que consideres adecuado en tu caso
-        else:
-            # Procesa la respuesta como JSON
-            print(f"response Socket {decoded_response}")
-            return {}
+            # Receive the response from the server
+            response = s.recv(65536)
+            
+            # Decode the response
+            decoded_response = response.decode('utf-8')
+            
+            # Handle empty response
+            if not decoded_response:
+                # If the response is empty, you can simply return a default value or continue
+                return {}  # You can change this to whatever is appropriate in your case
+            else:
+                # Process the response as JSON
+                logger.info(f"Socket response: {decoded_response}")
+                return {}
+    except socket.error as e:
+        error_message = (
+            f"Socket error: Unable to connect to the socket at {host}:{port}. "
+            f"To receive information, please ensure that the socket is up and running on {host} and port {port}."
+        )
+        logger.warning(error_message)
+        return {}
+


### PR DESCRIPTION
# Add Request Trace View and Client Determination Fix

## What this PR does

1. Created the view to display the trace of requests captured by the proxy.
2. Fixed the issue when determining the client.
3. The table now includes filtering based on its properties.

## Next Steps

1. Add the request detail view.
2. Update the current design of the ViewModels to use `EnvironmentObjects` instead of classical composition with dependency injection.



https://github.com/user-attachments/assets/f6fc8dc7-e39c-4e08-9944-5e241b729dbe

